### PR TITLE
Improved docker and added Tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY requirements.txt /opt/$NAME/requirements.txt
 RUN cd /opt/$NAME && pip install -r requirements.txt
 
 COPY main.py /opt/$NAME/main.py
+COPY gunicorn.py /opt/$NAME/gunicorn.py
 COPY entrypoint.sh /opt/$NAME/entrypoint.sh
 
 # Copy the application folder inside the container
@@ -33,3 +34,4 @@ EXPOSE 5000
 
 # Launch script
 ENTRYPOINT ["./entrypoint.sh"]
+#CMD [echo, "Excecuted echo in dockerfile"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ To run the Flask microservice:
 1. Ensure Docker is installed.
 1. Ensure the .env file is present contains the EE_PRIVATE_KEY and EE_USER environment variables.
 1. Ensure the `start.sh` script can be executed (`chmod +x start.sh`).
-1. Execute the start script with a flag indicating if this is a development or production environment: e.g.
+1. Execute the start script with a flag indicating if this is a development or production environment, or a test: e.g.
+   - `./start.sh test`
    - `./start.sh develop`
    - `./start.sh depoly`
   
@@ -23,6 +24,7 @@ Note: If a development server is started, the app is ultimatley executed with a 
 running the Flask app in development mode. However, if a deoply server is started, the app is executed with
 [Gunicorn](http://gunicorn.org/#docs), using the settings in `gunicorn.py`.
 
+Tests run using py.test.
 
 ### Using the Microservice
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,30 @@ A Microservice using Flask to identify statistics around a buffered point. Input
 
 
 
-### Docker: starting the Microservice
-To run the Flask microservice
+### Starting the Microservice
+To run the Flask microservice:
+1. Pull this repo, and `cd` to the folder.
 1. Ensure Docker is installed.
-1. Ensuring the .env file is present containing the EE_PRIVATE_KEY and EE_USER environment variables,
-1. `$chmod +x start.sh`
-1. `$./start.sh`
+1. Ensure the .env file is present contains the EE_PRIVATE_KEY and EE_USER environment variables.
+1. Ensure the `start.sh` script can be executed (`chmod +x start.sh`).
+1. Execute the start script with a flag indicating if this is a development or production environment: e.g.
+   - `./start.sh develop`
+   - `./start.sh depoly`
+  
+At this point, the microservice should be accessible on localhost:8000.
 
-At this point, the microservice should be active on localhost:8000.
+Note: If a development server is started, the app is ultimatley executed with a `python main.py` command,
+running the Flask app in development mode. However, if a deoply server is started, the app is executed with
+[Gunicorn](http://gunicorn.org/#docs), using the settings in `gunicorn.py`.
 
 
 ### Using the Microservice
 
- POST request and response:
+The app accepts POST requests, expecting values for `lat`, `lon` (both floats, of decimal degrees), and `z` (an integer
+from 1-12). It gives a json-like response:
 
 ```bash
 $ curl -i -H "Content-Type: application/json" -X POST -d '{"lat":28.5, "lon":16.3, "z":3}' http://localhost:5000/api/click-point-data/
-
 {
   "task": {
     "b1_count": 32,
@@ -43,51 +50,5 @@ If the process is unresponsive to closing with `ctl + c`, obtain the docker ID a
 $docker ps
 CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS              PORTS                    NAMES
 3ad44399b2be        flask_app           "./entrypoint.sh"   About a minute ago   Up About a minute   0.0.0.0:8000->5000/tcp   kind_elion
-
 $docker stop 3ad44399b2be
-```
-
-### Extended Notes
-
-
-Python 2.7 app built using Flask, and python-earth-engine-api.
-
-1. Install the requirements via pip
-
-```
-pip install -r requirements.txt
-```
-
-2. start the app
-
-```bash
-$python main.py
-```
-
-2. Send a POST request with lat, lon, and z information: e.g. to /api/click-point-data/
-
-```
-$ curl -i -H "Content-Type: application/json" -X POST -d '{"lat":28.5, "lon":16.3, "z":3}' http://localhost:5000/api/click-point-data/
-````
-
-Example response...
-
-```
-curl -i -H "Content-Type: application/json" -X POST -d '{"lat":28.5, "lon":16.3, "z":3}' http://localhost:5000/api/click-point-data/
-HTTP/1.0 201 CREATED
-Content-Type: application/json
-Content-Length: 181
-Server: Werkzeug/0.11.15 Python/2.7.12
-Date: Fri, 03 Feb 2017 13:31:14 GMT
-
-{
-  "task": {
-    "tavg_count": 32,
-    "tavg_max": 207.0,
-    "tavg_mean": 206.75,
-    "tavg_min": 206.0,
-    "tavg_stdDev": 0.43994134506405985,
-    "tavg_sum": 6616.0
-  }
-}
 ```

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -1,0 +1,13 @@
+develop:
+  build: .
+  ports:
+    - "8000:5000"
+  env_file:
+    - .env
+  environment:
+    ENVIRONMENT: dev
+    DEBUG: "True"
+  volumes:
+    - .:/opt/flask_app/
+  command: develop
+  restart: always

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,0 +1,12 @@
+develop:
+  build: .
+  ports:
+    - "8000:5000"
+  env_file:
+    - .env
+  environment:
+    ENVIRONMENT: dev
+    DEBUG: "True"
+  volumes:
+    - .:/opt/flask_app/
+  command: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+production:
+  build: .
+  ports:
+    - "8000:5000"
+  volumes:
+    - .:/opt/flask_app/
+  env_file:
+    - .env
+  command: production
+  restart: always

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,9 @@ case "$1" in
         exec python main.py
         ;;
     test)
-        echo "Test (not yet)"
+        echo "Running Tests"
+        echo -e "$EE_PRIVATE_KEY" | base64 -d > privatekey.pem
+        exec py.test -v
         ;;
     production)
         echo "Running Production Server"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
+set -e
 
-echo "Running python process"
-echo -e "$EE_PRIVATE_KEY" | base64 -d > privatekey.pem
-#exec gunicorn -w 2 main:app
-exec python main.py
+case "$1" in
+    develop)
+        echo "Running Development Server"
+        echo -e "$EE_PRIVATE_KEY" | base64 -d > privatekey.pem
+        exec python main.py
+        ;;
+    test)
+        echo "Test (not yet)"
+        ;;
+    production)
+        echo "Running Production Server"
+        echo -e "$EE_PRIVATE_KEY" | base64 -d > privatekey.pem
+        #exec gunicorn -w 2 main:app
+        exec gunicorn -c gunicorn.py main:app
+        ;;
+    *)
+        exec "$@"
+esac

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -1,0 +1,80 @@
+import os
+import multiprocessing
+
+bind = '0.0.0.0:5000'
+backlog = 2048
+
+worker_class = 'gevent'
+workers = 2
+threads = 1
+worker_connections = 1000
+timeout = 30
+keepalive = 2
+max_requests = 1000
+max_requests_jitter = 50
+
+spew = False
+
+daemon = False
+pidfile = None
+umask = 666
+user = os.getenv('USER')
+group = os.getenv('USER')
+tmp_upload_dir = None
+
+errorlog = '-'
+loglevel = 'info'
+accesslog = '-'
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+
+proc_name = None
+
+#
+# Server hooks
+#
+#   post_fork - Called just after a worker has been forked.
+#
+#       A callable that takes a server and worker instance
+#       as arguments.
+#
+#   pre_fork - Called just prior to forking the worker subprocess.
+#
+#       A callable that accepts the same arguments as after_fork
+#
+#   pre_exec - Called just prior to forking off a secondary
+#       master process during things like config reloading.
+#
+#       A callable that takes a server instance as the sole argument.
+#
+
+def post_fork(server, worker):
+    server.log.info("Worker spawned (pid: %s)", worker.pid)
+
+def pre_fork(server, worker):
+    pass
+
+def pre_exec(server):
+    server.log.info("Forked child, re-executing.")
+
+def when_ready(server):
+    server.log.info("Server is ready. Spawning workers")
+
+def worker_int(worker):
+    worker.log.info("worker received INT or QUIT signal")
+
+    ## get traceback info
+    import threading, sys, traceback
+    id2name = dict([(th.ident, th.name) for th in threading.enumerate()])
+    code = []
+    for threadId, stack in sys._current_frames().items():
+        code.append("\n# Thread: %s(%d)" % (id2name.get(threadId,""),
+            threadId))
+        for filename, lineno, name, line in traceback.extract_stack(stack):
+            code.append('File: "%s", line %d, in %s' % (filename,
+                lineno, name))
+            if line:
+                code.append("  %s" % (line.strip()))
+    worker.log.debug("\n".join(code))
+
+def worker_abort(worker):
+    worker.log.info("worker received SIGABRT signal")

--- a/main.py
+++ b/main.py
@@ -85,6 +85,7 @@ class ClickPointData(flask_restful.Resource):
 # set up routes
 api.add_resource(ClickPointData, '/api/click-point-data/')
 
+# This is only used when running locally. When running live, Gunicorn runs the application.
 if __name__ == "__main__":
     if sys.platform == 'darwin':
         app.run(host='0.0.0.0', debug=os.getenv('DEBUG') == 'True')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ earthengine-api==0.1.95
 flask==0.12
 flask_restful==0.3.5
 oauth2client==1.5.2
+pytest==3.0.5

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ case "$1" in
         docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
         ;;
     test)
-        echo "Test (not yet)"
+        docker-compose -f docker-compose-test.yml build && docker-compose -f docker-compose-test.yml up
         ;;
     production)
         docker-compose -f docker-compose.yml build && docker-compose -f docker-compose.yml up

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-NAME=flask_app
-docker build -t $NAME --build-arg NAME=$NAME .
-#docker run -it -v $(pwd)/data:/opt/$NAME/data --env-file .env --rm $NAME "/bin/bash"
-chmod +x entrypoint.sh
-docker run -v $(pwd):/opt/$NAME -p 8000:5000 --env-file .env --rm $NAME
+case "$1" in
+    develop)
+        docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
+        ;;
+    test)
+        echo "Test (not yet)"
+        ;;
+    production)
+        docker-compose -f docker-compose.yml build && docker-compose -f docker-compose.yml up
+        ;;
+    *)
+        exec "$@"
+esac

--- a/test_main.py
+++ b/test_main.py
@@ -1,27 +1,24 @@
-from flask_testing import TestCase
-import requests
-import urllib2
-from main import app
-#
-# Curerntly, started working on tests - not functional yet
+from __future__ import print_function, division
+from main import ClickPointData
+import sys
+import ee
+import os
 
-class MyTest(TestCase):
-    def create_app(self):
-        app.config['TESTING'] = True
-        return app
+if sys.platform == 'darwin':
+    local_system = True
+    # If using a local mac, assume you can initilise using the below...
+    ee.Initialize()
+else:
+    # Else, assume you have an EE_private_key environment variable with authorisation,
+    service_account = os.environ['EE_USER']
+    print(service_account)
+    credentials = ee.ServiceAccountCredentials(service_account, './privatekey.pem')
+    ee.Initialize(credentials, 'https://earthengine.googleapis.com')
 
-class TestViews(MyTest):
+# Going to test the functionality of the app directly via the return_ee_stats method
 
-    # def test_post(self):
-    #     r = requests.post('http://localhost:5001/api/click-point-data/', data={'lat':10, 'lon':10, 'z':3}).json()
-    #     print(r)
-    #     return
-
-    # def test_get(self):
-    #     response = self.client.get("/api/click-point-data/", data={'lat':10, 'lon':10, 'z':3})
-    #     print("RESPONSE WAS: ", response)
-    #     return
-
-    # def test_flask_application_is_up_and_running(self):
-    #     response = urllib2.urlopen(self.get_server_url())
-    #     self.assertEqual(response.code, 200)
+def test_basic_response():
+    r = ClickPointData().return_ee_stats({'lon': 10, 'lat': 10, 'z': 1})
+    print("Returned ", r)
+    assert isinstance(r, dict)
+    return

--- a/test_main.py
+++ b/test_main.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, division
 from main import ClickPointData
 import sys
+import pytest
 import ee
 import os
 
@@ -17,8 +18,34 @@ else:
 
 # Going to test the functionality of the app directly via the return_ee_stats method
 
-def test_basic_response():
-    r = ClickPointData().return_ee_stats({'lon': 10, 'lat': 10, 'z': 1})
-    print("Returned ", r)
-    assert isinstance(r, dict)
+def test_basic_response_zoomed():
+    expected = {'2017_mean': '  3.98', '2008_mean': '  6.02'}
+    d = {'lon': -16.3, 'lat': 28.5, 'z': 12}
+    r = ClickPointData().return_ee_stats(d)
+    assert isinstance(r, dict), "Return was not of dictionary type"
+    assert r == expected, "Returned dictionary {r} incorrect".format(r=r)
+    return
+
+def test_basic_response_distant():
+    expected = {'2017_mean': ' 71.08', '2008_mean': '106.74'}
+    d = {'lon': -16.3, 'lat': 28.5, 'z': 0}
+    r = ClickPointData().return_ee_stats(d)
+    assert r == expected, "Returned dictionary {r} incorrect".format(r=r)
+    return
+
+def test_point_distant():
+    """Check a buffered area was within 10% of the expected size for distant zoom level"""
+    target_size = 75936587859
+    d = {'lon': -16.3, 'lat': 28.5, 'z': 0}
+    p = ClickPointData().eePoint(d).area().getInfo()
+    assert p == pytest.approx(target_size, rel=0.1)
+    return
+
+
+def test_point_zoomed():
+    """Check a buffered area was within 10% of the expected size for closest zoom level"""
+    target_size = 152098957.601
+    d = {'lon': -16.3, 'lat': 28.5, 'z': 12}
+    p = ClickPointData().eePoint(d).area().getInfo()
+    assert p == pytest.approx(target_size, rel=0.1)
     return


### PR DESCRIPTION
* `./start.sh` now expects one of three arguments: *test*, *develop* or *production*
* The start script now uses a new way of executing docker, via docker-config files.
* Development server, deployed server, and test suit now running.
* Restarting of docker on failed production server should now be automatic
* Added four tests
* Updated Readme file
* Now using Gunicorn on deploy server to manage the python processes.